### PR TITLE
Rq dummy partner estimator

### DIFF
--- a/hummingbird_odometry/src/ts_location_estimator.cpp
+++ b/hummingbird_odometry/src/ts_location_estimator.cpp
@@ -38,6 +38,49 @@ geometry_msgs::Transform load_calibration(ros::NodeHandle& nh, string transform_
     return transform;
 }
 
+string me_frame_id = "base_link";
+string partner_frame_id = "partner";
+const int NUM_TAGS = 6; 
+tf2::Matrix3x3 correctionMatricies[NUM_TAGS] = {
+    tf2::Matrix3x3(0,-1,0,0,0,1,-1,0,0),
+    tf2::Matrix3x3(0,-1,0,0,0,1,-1,0,0),
+    tf2::Matrix3x3(0,1,0,0,0,1,1,0,0),
+    tf2::Matrix3x3(0,1,0,0,0,1,1,0,0),
+    tf2::Matrix3x3(0,1,0,0,0,1,1,0,0),
+    tf2::Matrix3x3(0,1,0,0,0,1,1,0,0),
+};
+double tagOffsets[NUM_TAGS][3] = {
+    {0.14, -0.157, -0.02},
+    {-0.14, -0.157, -0.02},
+    {-0.14, -0.157, -0.02},
+    {0.14, -0.157, -0.02},
+    {-0.054, -0.182, -0.02},
+    {0.054, -0.182, -0.02}
+};
+
+geometry_msgs::TransformStamped currentPartnerEstimate;
+bool estimateValid = false; 
+
+// Updates the estimated partner transformation
+// Returns true if the estimate was updated
+// Tag number is [1, TAG_NUMBER]
+bool estimatePartnerPosition(geometry_msgs::TransformStamped tagTransform,
+                             int tagNumber) {
+    currentPartnerEstimate.header.stamp = ros::Time::now();
+    currentPartnerEstimate.header.frame_id = me_frame_id;
+    currentPartnerEstimate.child_frame_id = partner_frame_id;
+    if (tagNumber == 3) {
+        currentPartnerEstimate.transform = tagTransform.transform;
+        return true; // Estimate position of partner as the position of the 3rd tag for now.
+    }
+    return false;
+}
+
+/*
+ * This node attempts to determine the location of the partner tailsitter relative to itself.
+ * It does this by looking up the transformations from itself to the apriltags, adding a correction to orientate
+ * correctly and adjust offsets, and calculates an estimate of the partner's location
+ */
 int main(int argc, char** argv){
     ros::init(argc, argv, "apriltag_destination");
 
@@ -50,98 +93,38 @@ int main(int argc, char** argv){
     ros::Rate rate(60.0);
 
     while (node.ok()){
+        geometry_msgs::TransformStamped tagTransforms[NUM_TAGS];
+        tf2::Quaternion qCorrect;
 
-        geometry_msgs::PoseArray poseArray;
-
-        int totalTags = 0;
-
-        vector<geometry_msgs::PoseStamped> possiblePoses;
-        vector<geometry_msgs::TransformStamped> possibleTransforms;
-
-        for (int i = 1; i < 7; ++i) {
-            try{
-                geometry_msgs::TransformStamped world_apriltag;
-                world_apriltag = tfBuffer.lookupTransform("world", "tag" + to_string(i), ros::Time(0));
-
-                geometry_msgs::TransformStamped ts_transform;
-                tf2::Quaternion q;
-                if(i == 1) {
-
-                    ts_transform.transform.translation.x = 0.14;
-                    ts_transform.transform.translation.y = -0.157; // -0.357
-                    ts_transform.transform.translation.z = -0.02;
-
-                    tf2::Matrix3x3 m(0,-1,0,0,0,1,-1,0,0);
-                    m.getRotation(q);
-
-                }
-                else if (i == 2) {
-                    ts_transform.transform.translation.x = -0.14;
-                    ts_transform.transform.translation.y = -0.157; // -0.357
-                    ts_transform.transform.translation.z = -0.02;
-
-                    tf2::Matrix3x3 m(0,-1,0,0,0,1,-1,0,0);
-                    m.getRotation(q);
-                }
-                else if (i == 3) {
-                    ts_transform.transform.translation.x = -0.14;
-                    ts_transform.transform.translation.y = -0.157; // -0.357
-                    ts_transform.transform.translation.z = -0.02;
-
-                    tf2::Matrix3x3 m(0,1,0,0,0,1,1,0,0);
-                    m.getRotation(q);
-                }
-                else if (i == 4) {
-                    ts_transform.transform.translation.x = 0.14;
-                    ts_transform.transform.translation.y = -0.157; // -0.357
-                    ts_transform.transform.translation.z = -0.02;
-
-                    tf2::Matrix3x3 m(0,1,0,0,0,1,1,0,0);
-                    m.getRotation(q);
-                }
-                else if (i == 5) {
-                    ts_transform.transform.translation.x = -0.054;
-                    ts_transform.transform.translation.y = -0.182; // -0.382
-                    ts_transform.transform.translation.z = -0.02;
-
-                    tf2::Matrix3x3 m(0,1,0,0,0,1,1,0,0);
-                    m.getRotation(q);
-                }
-                else if (i == 6) {
-                    ts_transform.transform.translation.x = 0.054;
-                    ts_transform.transform.translation.y = -0.182; // -0.382
-                    ts_transform.transform.translation.z = -0.02;
-
-                    tf2::Matrix3x3 m(0,1,0,0,0,1,1,0,0);
-                    m.getRotation(q);
-                }
-
-                ts_transform.header.stamp = ros::Time::now();
-                ts_transform.header.frame_id = "tag" + to_string(i);
-                ts_transform.child_frame_id = "t" + to_string(i);
-                ts_transform.transform.rotation.x = q.x();
-                ts_transform.transform.rotation.y = q.y();
-                ts_transform.transform.rotation.z = q.z();
-                ts_transform.transform.rotation.w = q.w();
-
-                br.sendTransform(ts_transform);
-
-                // Calibration
-                geometry_msgs::Transform tagCalibration = load_calibration(node, "tag" + to_string(i));
-
-                geometry_msgs::TransformStamped tagCalibrationStamped;
-                tagCalibrationStamped.transform = tagCalibration;
-                tagCalibrationStamped.header = ts_transform.header;
-                tagCalibrationStamped.header.frame_id = "t" + to_string(i);
-                tagCalibrationStamped.child_frame_id = "ts" + to_string(i);
-                br.sendTransform(tagCalibrationStamped);
-
-            }
-            catch (tf2::TransformException & ex){
+        for (int i = 0; i < NUM_TAGS; ++i) {
+            string from = me_frame_id;
+            string to = "tag" + to_string(i+1);
+            // Lookup transform from base_link to ith tag
+            try {
+                tagTransforms[i] = tfBuffer.lookupTransform(from, to, ros::Time(0));
+            } catch (tf2::TransformException & ex){
+                ROS_WARN("%s",ex.what());
                 continue;
             }
+            tf2::Quaternion qTag(tagTransforms[i].transform.rotation.x, 
+                                 tagTransforms[i].transform.rotation.y,
+                                 tagTransforms[i].transform.rotation.z,
+                                 tagTransforms[i].transform.rotation.w);
+            correctionMatricies[i].getRotation(qCorrect);
+            qTag = qTag*qCorrect;
+            tagTransforms[i].transform.rotation.x = qTag.x();
+            tagTransforms[i].transform.rotation.y = qTag.y();
+            tagTransforms[i].transform.rotation.z = qTag.z();
+            tagTransforms[i].transform.rotation.w = qTag.w();
+            // Set header and publish
+            tagTransforms[i].header.stamp = ros::Time::now();
+            tagTransforms[i].header.frame_id = from;
+            tagTransforms[i].child_frame_id = to + "_corrected";
+            br.sendTransform(tagTransforms[i]);
+            if (estimatePartnerPosition(tagTransforms[i], i+1)) {
+                br.sendTransform(currentPartnerEstimate);
+            }
         }
-
         rate.sleep();
     }
     return 0;

--- a/hummingbird_odometry/src/ts_location_estimator.cpp
+++ b/hummingbird_odometry/src/ts_location_estimator.cpp
@@ -14,6 +14,29 @@
 
 using namespace std;
 
+string me_frame_id = "base_link";
+string partner_frame_id = "partner";
+const int NUM_TAGS = 6; 
+tf2::Matrix3x3 correctionMatricies[NUM_TAGS] = {
+    tf2::Matrix3x3(0,-1,0,0,0,1,-1,0,0),
+    tf2::Matrix3x3(0,-1,0,0,0,1,-1,0,0),
+    tf2::Matrix3x3(0,1,0,0,0,1,1,0,0),
+    tf2::Matrix3x3(0,1,0,0,0,1,1,0,0),
+    tf2::Matrix3x3(0,1,0,0,0,1,1,0,0),
+    tf2::Matrix3x3(0,1,0,0,0,1,1,0,0),
+};
+double tagOffsets[NUM_TAGS][3] = {
+    {0.14, -0.157, -0.02},
+    {-0.14, -0.157, -0.02},
+    {-0.14, -0.157, -0.02},
+    {0.14, -0.157, -0.02},
+    {-0.054, -0.182, -0.02},
+    {0.054, -0.182, -0.02}
+};
+
+geometry_msgs::TransformStamped currentPartnerEstimate;
+bool estimateValid = false; 
+
 geometry_msgs::Transform load_calibration(ros::NodeHandle& nh, string transform_name) {
     double x, y, z, rx, ry, rz, rw;
     nh.param<double>("odometry/" + transform_name + "/calib/translation/x", x, 0.0);
@@ -37,29 +60,6 @@ geometry_msgs::Transform load_calibration(ros::NodeHandle& nh, string transform_
 
     return transform;
 }
-
-string me_frame_id = "base_link";
-string partner_frame_id = "partner";
-const int NUM_TAGS = 6; 
-tf2::Matrix3x3 correctionMatricies[NUM_TAGS] = {
-    tf2::Matrix3x3(0,-1,0,0,0,1,-1,0,0),
-    tf2::Matrix3x3(0,-1,0,0,0,1,-1,0,0),
-    tf2::Matrix3x3(0,1,0,0,0,1,1,0,0),
-    tf2::Matrix3x3(0,1,0,0,0,1,1,0,0),
-    tf2::Matrix3x3(0,1,0,0,0,1,1,0,0),
-    tf2::Matrix3x3(0,1,0,0,0,1,1,0,0),
-};
-double tagOffsets[NUM_TAGS][3] = {
-    {0.14, -0.157, -0.02},
-    {-0.14, -0.157, -0.02},
-    {-0.14, -0.157, -0.02},
-    {0.14, -0.157, -0.02},
-    {-0.054, -0.182, -0.02},
-    {0.054, -0.182, -0.02}
-};
-
-geometry_msgs::TransformStamped currentPartnerEstimate;
-bool estimateValid = false; 
 
 // Updates the estimated partner transformation
 // Returns true if the estimate was updated


### PR DESCRIPTION
Hey Jason.

So I changed the tag estimates to be output relative to the base_link because in the end that is what we want to position based on, without vicon being involved.

I also consolidated code by putting the data in arrays.

I was working on your simulink model and there was no estimate being output so as a dirty solution I just made it equal to tag3.

Also, it seems like ts_location_estimator was actually publishing corrected apriltag estimates which is unintuitive based on the name. And then ts_location_publisher actually published an array of tag estimates. I think it's an unnecessary step to write another node that subscribes to those to do the actual estimation but at the very least we should rename these two files to tag_location_estimator and tag_location_publisher. But based on the naming, I changed it to what I expected. estimatePartnerPosition() continuously updates the partner transform based on the tag reading in ts_location_estimator and ts_location_estimator publishes one transform for the partner tailsitter.

Finally, I don't understand what the calibration code does so it's not called. Please lmk what it does!

Let me know what you think.